### PR TITLE
bugfix: 修复 Tree 异步加载时loading 图标靠下的问题

### DIFF
--- a/src/ui/tree.css
+++ b/src/ui/tree.css
@@ -60,6 +60,7 @@
         width: 14px;
         height: 14px;
         display: inline-block;
+        top: -5px;
     }
     .node-title {
         display: inline-block;


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- bugfix: 修复 Tree 异步加载时loading 图标靠下的问题