### PR TITLE
bugfix(loading): 修复zIndex的默认值0导致不传参时层级错误问题

### DIFF
--- a/src/components/loading/loading.vue
+++ b/src/components/loading/loading.vue
@@ -163,8 +163,7 @@
             },
             /** 堆叠顺序 */
             zIndex: {
-                type: Number,
-                default: 0
+                type: Number
             },
             /** 消失完毕回调函数 */
             afterLeave: {


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes https://github.com/TencentBlueKing/bkui-vue2/issues/166`
-->


## 变更点(Changes)

- loading

## 相关issues (Which issues this PR fixes)

- Fixes # [issue](https://github.com/TencentBlueKing/bkui-vue2/issues/166)

## 备注(Special notes)
