### PR TITLE
bugfix: ToolTips组件在鼠标经过显示后，鼠标滚轮滚动页面，ToolTips不会消失

### DIFF
--- a/src/utils/tippy/index.js
+++ b/src/utils/tippy/index.js
@@ -29,7 +29,9 @@
 * (c) 2017-2019 atomiks
 * MIT License
 */
+
 import Popper from './popper.js';
+import { addWheelListener } from '../util.js';
 
 function _extends() {
   _extends = Object.assign || function (target) {
@@ -907,6 +909,14 @@ function createTippy(reference, collectionProps) {
       document.addEventListener('mousemove', debouncedOnMouseMove);
     }
   });
+
+   // 在 tooltips 上禁用鼠标滚轮默认事件
+   addWheelListener(popper, function(event) {
+    const ev = event || window.event
+    ev.stopPropagation && ev.stopPropagation()
+    ev.preventDefault && ev.preventDefault()
+  }, false)
+  
   return instance;
   /* ======================= 🔒 Private methods 🔒 ======================= */
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -358,3 +358,64 @@ export function checkOverflow (el) {
   }
   return isOverflow
 }
+
+/**
+ * 监听鼠标滚轮事件
+ * @param {Dom Object} elem 目标dom
+ * @param {callback} callback 回调函数
+ * @param {Dom Object} useCapture 是否冒泡
+ */
+
+ export function addWheelListener (elem, callback, useCapture) {
+  let prefix = ''
+  let _addEventListener
+  
+  if (window.addEventListener) {
+    _addEventListener = 'addEventListener'
+  } else {
+    _addEventListener = 'attachEvent'
+    prefix = 'on'
+  }
+  
+  const support = 'onwheel' in document.createElement('div') ? 'wheel' : document.onmousewheel !== undefined ? 'mousewheel' : 'DOMMouseScroll'
+  
+  function _addWheelListener (elem, eventName, callback, useCapture) {
+    elem[_addEventListener](
+      prefix + eventName,
+      support === 'wheel'
+        ? callback : function (originalEvent) {
+          !originalEvent && (originalEvent = window.event)
+
+          const event = {
+            originalEvent: originalEvent,
+            target: originalEvent.target || originalEvent.srcElement,
+            type: 'wheel',
+            deltaMode: originalEvent.type === 'MozMousePixelScroll' ? 0 : 1,
+            deltaX: 0,
+            deltaZ: 0,
+            preventDefault: function () {
+              originalEvent.preventDefault
+                ? originalEvent.preventDefault()
+                : (originalEvent.returnValue = false)
+            }
+          }
+
+          if (support === 'mousewheel') {
+            event.deltaY = (-1 / 40) * originalEvent.wheelDelta
+            originalEvent.wheelDeltaX && (event.deltaX = (-1 / 40) * originalEvent.wheelDeltaX)
+          } else {
+            event.deltaY = originalEvent.detail
+          }
+
+          return callback(event)
+        },
+      useCapture || false
+    )
+  }
+  
+  if (support === 'DOMMouseScroll') {
+    _addWheelListener(elem, 'MozMousePixelScroll', callback, useCapture)
+  } else {
+    _addWheelListener(elem, support, callback, useCapture)
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58067499/164683501-cfb1ccf2-adc8-4129-bfe8-0f10d44c6434.png)

解决`tooltips`鼠标滚动一直不消失的问题；采用`element-ui`的解决方案，即当鼠标移动到`tooltips`组件上时，禁用鼠标滚动事件 