### PR TITLE
bugfix: 修复在使用Image,ZoomImage组件时,当祖先某些属性非 none 时 图片被遮盖的问题 issue #249

### DIFF
--- a/example/components/image/readme.md
+++ b/example/components/image/readme.md
@@ -268,35 +268,42 @@
 ### 大图预览 {page=#/image}
 
 :::demo 可通过 `previewSrcList` 开启预览大图的功能。
+
 ```html
+
 <template>
-    <div>
-        <bk-image style="width: 200px;" :src="previewSrc" :preview-src-list="srcList"></bk-image>
-    </div>
+  <div>
+    <bk-image style="width: 200px;" :src="previewSrc" :preview-src-list="srcList"></bk-image>
+  </div>
 </template>
 
 <script>
-    import { bkImage } from '{{BASE_LIB_NAME}}'
-    export default {
-        data () {
-            return {
-                previewSrc: './example/static/images/preview/0.png',
-                srcList: [
-                    './example/static/images/preview/0.png',
-                    './example/static/images/preview/1.png',
-                    './example/static/images/preview/2.png',
-                    './example/static/images/preview/3.png',
-                    './example/static/images/preview/33.png',
-                    './example/static/images/preview/4.png',
-                    './example/static/images/preview/55.png',
-                    './example/static/images/preview/5.png',
-                    './example/static/images/preview/6.png',
-                ]
-            }
-        }
+  import { bkImage, bkTable } from '{{BASE_LIB_NAME}}'
+  export default {
+    data () {
+      return {
+        previewSrc: './example/static/images/preview/0.png',
+        srcList: [
+          './example/static/images/preview/0.png',
+          './example/static/images/preview/1.png',
+          './example/static/images/preview/2.png',
+          './example/static/images/preview/3.png',
+          './example/static/images/preview/33.png',
+          './example/static/images/preview/4.png',
+          './example/static/images/preview/55.png',
+          './example/static/images/preview/5.png',
+          './example/static/images/preview/6.png',
+        ]
+      }
     }
+  }
 </script>
-
+<script>
+  import BkTableColumn from './table-column'
+  export default {
+    components: { BkTableColumn }
+  }
+</script>
 ```
 :::
 

--- a/src/components/image-viewer/image-viewer.vue
+++ b/src/components/image-viewer/image-viewer.vue
@@ -28,70 +28,72 @@
 
 <template>
   <transition name="bk-zoom">
-    <div tabindex="-1" ref="bk-image-viewer-wrapper" class="bk-image-viewer-wrapper"
-      :style="{ 'z-index': zIndex }">
-      <div class="bk-image-viewer-mask" @click="maskClose && hide()"></div>
-      <div v-if="isShowTitle && urlList.length" class="bk-image-viewer-header">
-        <div>{{currentName}}</div>
-        <div class="tc ">{{index + 1}}/{{urlList.length}}</div>
-        <div class="quit-box tr">
-          <div class="quit-tips mr10">{{t('bk.imageViewer.quitTips')}}</div>
-          <!-- CLOSE -->
-          <div class="bk-image-viewer-close" @click="hide">
-            <i class="bk-icon icon-close"></i>
+    <div style="position: absolute; top: -100000px; left: -100000px;" :data-transfer="true" v-transfer-dom>
+      <div tabindex="-1" ref="bk-image-viewer-wrapper" class="bk-image-viewer-wrapper"
+        :style="{ 'z-index': zIndex }">
+        <div class="bk-image-viewer-mask" @click="maskClose && hide()"></div>
+        <div v-if="isShowTitle && urlList.length" class="bk-image-viewer-header">
+          <div>{{currentName}}</div>
+          <div class="tc ">{{index + 1}}/{{urlList.length}}</div>
+          <div class="quit-box tr">
+            <div class="quit-tips mr10">{{t('bk.imageViewer.quitTips')}}</div>
+            <!-- CLOSE -->
+            <div class="bk-image-viewer-close" @click="hide">
+              <i class="bk-icon icon-close"></i>
+            </div>
           </div>
         </div>
-      </div>
-      <!-- ARROW -->
-      <template v-if="!isSingle">
-        <div
-          class="bk-image-viewer-btn bk-image-viewer-prev"
-          :class="{ 'is-disabled': !infinite && isFirst }"
-          @click="prev">
-          <i class="bk-icon icon-angle-left" />
+        <!-- ARROW -->
+        <template v-if="!isSingle">
+          <div
+            class="bk-image-viewer-btn bk-image-viewer-prev"
+            :class="{ 'is-disabled': !infinite && isFirst }"
+            @click="prev">
+            <i class="bk-icon icon-angle-left" />
+          </div>
+          <div
+            class="bk-image-viewer-btn bk-image-viewer-next"
+            :class="{ 'is-disabled': !infinite && isLast }"
+            @click="next">
+            <i class="bk-icon icon-angle-right" />
+          </div>
+        </template>
+        <!-- ACTIONS -->
+        <div class="bk-image-viewer-btn bk-image-viewer-actions">
+          <div class="bk-image-viewer-actions-inner">
+            <i class="bk-icon icon-narrow-line" @click="handleActions('zoomOut')"
+              v-bk-tooltips.top="t('bk.image.zoomOut')" />
+            <i class="bk-icon icon-enlarge-line" @click="handleActions('zoomIn')"
+              v-bk-tooltips.top="t('bk.image.zoomIn')" />
+            <i class="bk-icon icon-normalized" @click="toggleMode('original')"
+              v-bk-tooltips.top="t('bk.image.original')" />
+            <i class="bk-icon icon-left-turn-line" @click="handleActions('anticlocelise')"
+              v-bk-tooltips.top="t('bk.image.rotateLeft')" />
+            <i class="bk-icon icon-right-turn-line" @click="handleActions('clockwise')"
+              v-bk-tooltips.top="t('bk.image.rotateRight')" />
+            <i class="bk-icon icon-unfull-screen" @click="toggleMode('contain')"
+              v-bk-tooltips.top="t('bk.image.fullScreen')" />
+          </div>
         </div>
-        <div
-          class="bk-image-viewer-btn bk-image-viewer-next"
-          :class="{ 'is-disabled': !infinite && isLast }"
-          @click="next">
-          <i class="bk-icon icon-angle-right" />
+        <!-- CANVAS -->
+        <div class="bk-image-viewer-canvas" :class="{ 'bk-image-viewer-has-header': isShowTitle }">
+          <div class="bk-image-viewer-error" v-if="error">
+            <div><i class="bk-icon icon-image-fail"></i></div>
+            <div>{{t('bk.imageViewer.loadFailed')}}</div>
+          </div>
+          <img
+            v-for="(url, i) in urlList"
+            v-if="i === index"
+            :key="url"
+            v-show="!error"
+            ref="img"
+            class="bk-image-viewer-img"
+            :src="currentImg"
+            :style="imgStyle"
+            @load="handleImgLoad"
+            @error="handleImgError"
+            @mousedown="handleMouseDown" />
         </div>
-      </template>
-      <!-- ACTIONS -->
-      <div class="bk-image-viewer-btn bk-image-viewer-actions">
-        <div class="bk-image-viewer-actions-inner">
-          <i class="bk-icon icon-narrow-line" @click="handleActions('zoomOut')"
-            v-bk-tooltips.top="t('bk.image.zoomOut')" />
-          <i class="bk-icon icon-enlarge-line" @click="handleActions('zoomIn')"
-            v-bk-tooltips.top="t('bk.image.zoomIn')" />
-          <i class="bk-icon icon-normalized" @click="toggleMode('original')"
-            v-bk-tooltips.top="t('bk.image.original')" />
-          <i class="bk-icon icon-left-turn-line" @click="handleActions('anticlocelise')"
-            v-bk-tooltips.top="t('bk.image.rotateLeft')" />
-          <i class="bk-icon icon-right-turn-line" @click="handleActions('clockwise')"
-            v-bk-tooltips.top="t('bk.image.rotateRight')" />
-          <i class="bk-icon icon-unfull-screen" @click="toggleMode('contain')"
-            v-bk-tooltips.top="t('bk.image.fullScreen')" />
-        </div>
-      </div>
-      <!-- CANVAS -->
-      <div class="bk-image-viewer-canvas" :class="{ 'bk-image-viewer-has-header': isShowTitle }">
-        <div class="bk-image-viewer-error" v-if="error">
-          <div><i class="bk-icon icon-image-fail"></i></div>
-          <div>{{t('bk.imageViewer.loadFailed')}}</div>
-        </div>
-        <img
-          v-for="(url, i) in urlList"
-          v-if="i === index"
-          :key="url"
-          v-show="!error"
-          ref="img"
-          class="bk-image-viewer-img"
-          :src="currentImg"
-          :style="imgStyle"
-          @load="handleImgLoad"
-          @error="handleImgError"
-          @mousedown="handleMouseDown" />
       </div>
     </div>
   </transition>
@@ -100,6 +102,8 @@
 <script>
 import { addEvent, removeEvent } from '@/utils/dom'
 import locale from 'bk-magic-vue/lib/locale'
+import transferDom from '@/directives/transfer-dom'
+
 // import { throttle } from 'throttle-debounce'
 function rafThrottle (fn) {
   let locked = false
@@ -114,7 +118,11 @@ function rafThrottle (fn) {
 }
 export default {
   name: 'bk-image-viewer',
+  directives: {
+    transferDom
+  },
   mixins: [locale.mixin],
+
   props: {
     urlList: {
       type: Array,
@@ -166,6 +174,7 @@ export default {
       }
     }
   },
+
   computed: {
     isSingle () {
       return this.urlList.length <= 1

--- a/src/components/image/image.vue
+++ b/src/components/image/image.vue
@@ -85,7 +85,6 @@ export default {
   components: {
     bkImageViewer
   },
-
   mixins: [locale.mixin],
 
   props: {

--- a/src/components/zoom-image/zoom-image.vue
+++ b/src/components/zoom-image/zoom-image.vue
@@ -31,11 +31,12 @@
     <img :src="src" class="bk-real-image" @click="imgSrc = src">
     <transition name="fade">
       <div
-        style="position: absolute; top: -100000px; left: -100000px;"
+        v-if="imgSrc"
+        style="position: absolute; top: -100000px; left: -100000px;z-index: 9999"
         :data-transfer="true"
         class="bk-zoom-image"
         v-transfer-dom>
-        <section v-if="imgSrc"
+        <section
           class="bk-full-screen"
           @mousemove="mouseMove"
           @mouseup="mouseUp"

--- a/src/components/zoom-image/zoom-image.vue
+++ b/src/components/zoom-image/zoom-image.vue
@@ -30,37 +30,47 @@
   <section :class="[extCls, 'bk-zoom-image']">
     <img :src="src" class="bk-real-image" @click="imgSrc = src">
     <transition name="fade">
-      <section v-if="imgSrc"
-        class="bk-full-screen"
-        @mousemove="mouseMove"
-        @mouseup="mouseUp"
-      >
-        <img ref="screenImg"
-          :src="imgSrc"
-          @mousewheel.prevent="scrollImage"
-          @DOMMouseScroll.prevent="scrollImage"
-          @mousedown="mouseDown"
-          :class="[{ 'bk-zoom-init': isInit }, 'bk-full-image']"
-          :style="{
-            width: `${width}px`,
-            height: `${height}px`,
-            top: `${top}px`,
-            left: `${left}px`
-          }"
+      <div
+        style="position: absolute; top: -100000px; left: -100000px;"
+        :data-transfer="true"
+        class="bk-zoom-image"
+        v-transfer-dom>
+        <section v-if="imgSrc"
+          class="bk-full-screen"
+          @mousemove="mouseMove"
+          @mouseup="mouseUp"
         >
-      </section>
+          <img ref="screenImg"
+            :src="imgSrc"
+            @mousewheel.prevent="scrollImage"
+            @DOMMouseScroll.prevent="scrollImage"
+            @mousedown="mouseDown"
+            :class="[{ 'bk-zoom-init': isInit }, 'bk-full-image']"
+            :style="{
+              width: `${width}px`,
+              height: `${height}px`,
+              top: `${top}px`,
+              left: `${left}px`
+            }"
+          >
+        </section>
+      </div>
     </transition>
   </section>
 </template>
 
 <script>
+import transferDom from '@/directives/transfer-dom'
+
 export default {
   name: 'bk-zoom-image',
+  directives: {
+    transferDom
+  },
   props: {
     src: String,
     extCls: String
   },
-
   data () {
     return {
       imgSrc: '',


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

Image，ZoomImage组件图片被遮盖

## 相关issues (Which issues this PR fixes)
249

- Fixes #

## 备注(Special notes)
