### PR TITLE
feat: bump to 2.5.3-beta.7

### DIFF
--- a/example/components/changelog/readme.md
+++ b/example/components/changelog/readme.md
@@ -8,6 +8,42 @@
 
 <div class="changelog-wrapper">
 
+### 2.5.3-beta.7 {page=#/changelog}
+
+* **[fix]**:
+    - directives tooltips 的 allowHTML 默认配置改为 true，为了兼容之前 allowHtml 默认为 false 但是 tippy 中配置 allowHTML 为 true 的情况
+
+---
+
+### 2.5.3-beta.6 {page=#/changelog}
+
+* **[feat]**:
+    - [Input 输入框](#/input) 数字输入框不允许输入特殊字符 alt, ctrl, meta
+
+---
+
+### 2.5.3-beta.5 {page=#/changelog}
+
+* **[feat]**:
+    - [Input 输入框](#/input) 数字输入框不允许输入特殊字符 shift
+
+---
+
+### 2.5.3-beta.4 {page=#/changelog}
+
+* **[feat]**:
+    - [Input 输入框](#/input) 数字输入框不允许输入拼音
+
+---
+
+### 2.5.3-beta.2 {page=#/changelog}
+
+* **[fix]**:
+    - [Input 输入框](#/input) 修复 windows 系统下， 输入 `-1234` 后光标移动到 `-` 号前面再次输入数字的问题
+    - [TimePicker 时间选择器](#/time-picker) 修复编辑后，值没有更新的问题
+
+---
+
 ### 2.5.3-beta.1 {page=#/changelog}
 
 * **[fix]**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk-magic-vue",
-  "version": "2.5.3-beta.1",
+  "version": "2.5.3-beta.7",
   "description": "基于蓝鲸 Magicbox 和 Vue 的前端组件库",
   "main": "dist/bk-magic-vue.min.js",
   "files": [

--- a/src/directives/tooltips.js
+++ b/src/directives/tooltips.js
@@ -48,7 +48,7 @@ const defaultOptions = {
   interactive: true,
   boundary: 'window',
   content: '',
-  allowHTML: false,
+  allowHTML: true,
   extCls: ''
 }
 


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- [Input 输入框] 数字输入框不允许输入特殊字符 shift；不允许输入特殊字符 alt, ctrl, meta；不允许输入拼音
- directives tooltips 的 allowHTML 默认配置改为 true，为了兼容之前 allowHtml 默认为 false 但是 tippy 中配置 allowHTML 为 true 的情况
- [Input 输入框] 修复 windows 系统下， 输入 `-1234` 后光标移动到 `-` 号前面再次输入数字的问题
- [TimePicker 时间选择器] 修复编辑后，值没有更新的问题