### PR TITLE
feat: bump to 2.5.3-beta.8 && table 组件修复 setHeaderStyle 方法获取 bkTable 为空的问题

### DIFF
--- a/example/components/changelog/readme.md
+++ b/example/components/changelog/readme.md
@@ -8,6 +8,13 @@
 
 <div class="changelog-wrapper">
 
+### 2.5.3-beta.8 {page=#/changelog}
+
+* **[fix]**:
+    - [Table 表格](#/table) 修复 setHeaderStyle 方法获取 bkTable 为空的问题
+
+---
+
 ### 2.5.3-beta.7 {page=#/changelog}
 
 * **[fix]**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk-magic-vue",
-  "version": "2.5.3-beta.7",
+  "version": "2.5.3-beta.8",
   "description": "基于蓝鲸 Magicbox 和 Vue 的前端组件库",
   "main": "dist/bk-magic-vue.min.js",
   "files": [

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -673,8 +673,10 @@ export default {
   methods: {
     setHeaderStyle () {
       this.$nextTick(() => {
-        this.$refs.bkTable.style.setProperty('--customHeaderColor', this.customHeaderColor)
-        this.$refs.bkTable.style.setProperty('--customHeaderColorHover', this.customHeaderColorHover)
+        if (this.$refs.bkTable) {
+          this.$refs.bkTable.style.setProperty('--customHeaderColor', this.customHeaderColor)
+          this.$refs.bkTable.style.setProperty('--customHeaderColorHover', this.customHeaderColorHover)
+        }
       })
     },
     setCurrentRow (row) {


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- table 组件修复 setHeaderStyle 方法获取 bkTable 为空的问题