### PR TITLE
feat: bump to 2.4.15-beta.20 && tag-input 修复 `allow-create` 配置，输入空格也会创建 tag 的问题

### DIFF
--- a/example/components/changelog/readme.md
+++ b/example/components/changelog/readme.md
@@ -4,6 +4,13 @@
 
 <div class="changelog-wrapper">
 
+### 2.4.15-beta.20 {page=#/changelog}
+
+* **[fix]**:
+    - [TagInput 标签输入框](#/tag-input) 修复 `allow-create` 配置，输入空格也会创建 tag 的问题
+
+---
+
 ### 2.4.15-beta.19 {page=#/changelog}
 
 * **[fix]**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk-magic-vue",
-  "version": "2.4.15-beta.19",
+  "version": "2.4.15-beta.20",
   "description": "基于蓝鲸 Magicbox 和 Vue 的前端组件库",
   "main": "dist/bk-magic-vue.min.js",
   "files": [

--- a/src/components/tag-input/tag-input.vue
+++ b/src/components/tag-input/tag-input.vue
@@ -833,7 +833,7 @@ export default {
           ) {
             this.handlerResultSelect(this.renderList[this.focusItemIndex], 'select')
             this.showList = false
-          } else if (this.allowCreate) {
+          } else if (this.allowCreate && this.curInputValue.trim()) {
             event.preventDefault()
             const tag = this.curInputValue
             this.handlerResultSelect(tag, 'custom')


### PR DESCRIPTION
## 变更点(Changes)

- feat: bump to 2.4.15-beta.20 && tag-input 修复 `allow-create` 配置，输入空格也会创建 tag 的问题