### PR TITLE
feat: bump to 2.5.3-beta.12 && tag-input 修复 `allow-create` 配置，输入空格也会创建 tag 的问题

### DIFF
--- a/example/components/changelog/readme.md
+++ b/example/components/changelog/readme.md
@@ -8,6 +8,20 @@
 
 <div class="changelog-wrapper">
 
+### 2.5.3-beta.12 {page=#/changelog}
+
+* **[fix]**:
+    - [TagInput 标签输入框](#/tag-input) 修复 `allow-create` 配置，输入空格也会创建 tag 的问题
+
+---
+
+### 2.5.3-beta.11 {page=#/changelog}
+
+* **[fix]**:
+    - [Input 输入框](#/input) 数字输入框输入 `-` 后失去焦点后，如果设置了最小值，值变为最小值，没有设置最小值，值变为 0
+
+---
+
 ### 2.5.3-beta.9 {page=#/changelog}
 
 * **[fix]**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk-magic-vue",
-  "version": "2.5.3-beta.11",
+  "version": "2.5.3-beta.12",
   "description": "基于蓝鲸 Magicbox 和 Vue 的前端组件库",
   "main": "dist/bk-magic-vue.min.js",
   "files": [

--- a/src/components/tag-input/tag-input.vue
+++ b/src/components/tag-input/tag-input.vue
@@ -833,7 +833,7 @@ export default {
           ) {
             this.handlerResultSelect(this.renderList[this.focusItemIndex], 'select')
             this.showList = false
-          } else if (this.allowCreate) {
+          } else if (this.allowCreate && this.curInputValue.trim()) {
             event.preventDefault()
             const tag = this.curInputValue
             this.handlerResultSelect(tag, 'custom')


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- feat: bump to 2.5.3-beta.12 && tag-input 修复 `allow-create` 配置，输入空格也会创建 tag 的问题