### PR TITLE
feat: bump to 2.5.4-beta.7 && sideslider: 修复在`.bk-sideslider-content`容器内，不使用容器滚动而是使用自己 dom 元素滚动失败的问题

### DIFF
--- a/example/components/changelog/readme.md
+++ b/example/components/changelog/readme.md
@@ -8,6 +8,14 @@
 
 <div class="changelog-wrapper">
 
+### 2.5.4-beta.7 {page=#/changelog}
+
+* **[fix]**:
+    - [Sideslider 侧栏](#/sideslider) 修复在 `.bk-sideslider-content` 容器内，不使用此容器的滚动而是单独使用自己的 dom 元素滚动失败的问题
+
+---
+
+
 ### 2.5.4-beta.6 {page=#/changelog}
 
 * **[fix]**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk-magic-vue",
-  "version": "2.5.4-beta.6",
+  "version": "2.5.4-beta.7",
   "description": "基于蓝鲸 Magicbox 和 Vue 的前端组件库",
   "main": "dist/bk-magic-vue.min.js",
   "files": [

--- a/src/components/sideslider/sideslider.vue
+++ b/src/components/sideslider/sideslider.vue
@@ -176,7 +176,7 @@ export default {
 
         this.$nextTick(() => {
           if (this.$refs.content) {
-            addResizeListener(this.$refs.content, this.handleContentResize)
+            addResizeListener(this.$refs.content, this.handleContentResize, false)
           }
         })
 

--- a/src/utils/resize-events.js
+++ b/src/utils/resize-events.js
@@ -138,7 +138,7 @@ const createStyles = function () {
   }
 }
 
-export const addResizeListener = function (element, fn) {
+export const addResizeListener = function (element, fn, useCapture = true) {
   if (attachEvent) {
     element.attachEvent('onresize', fn)
   } else {
@@ -156,7 +156,7 @@ export const addResizeListener = function (element, fn) {
       element.appendChild(resizeTrigger)
 
       resetTrigger(element)
-      element.addEventListener('scroll', scrollListener, true)
+      element.addEventListener('scroll', scrollListener, useCapture)
 
       /* Listen for a css animation to detect element display/re-attach */
       if (animationStartEvent) {


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- feat: bump to 2.5.4-beta.7 && sideslider: 修复在`.bk-sideslider-content`容器内，不使用容器滚动而是使用自己 dom 元素滚动失败的问题