### PR TITLE
bugfix(select): 防止在搜索时使用回车选择到不存在的元素

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -764,7 +764,7 @@ export default {
         }
         return false
       })
-      if (option) {
+      if (option && Object.keys(option).length !== 0) {
         if (this.multiple && this.selected.includes(option.id)) {
           return false
         }


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->



## 变更点(Changes)

![image](https://user-images.githubusercontent.com/8267936/221811896-82a2cc88-0065-4816-87e8-16107a486ee3.png)

- 原有逻辑通过Enter选择搜索到的内容时仅判断option是否为null，并未判断实际上有没有选择到存在的选项，导致回车可以选择到空元素，新增校验修复该问题。


## 备注(Special notes)
