### PR TITLE
bugfix: 修复 tooltip 弹层中无法滚动的问题 && bump to 2.5.5

### DIFF
--- a/example/components/changelog/readme.md
+++ b/example/components/changelog/readme.md
@@ -8,7 +8,8 @@
 
 <div class="changelog-wrapper">
 
-### 2.5.5-beta.1 {page=#/changelog}
+### 2.5.5 {page=#/changelog}
+###### 2023.05.29
 
 * **[fix]**:
     - 修复 tooltip 弹层中无法滚动的问题

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk-magic-vue",
-  "version": "2.5.5-beta.1",
+  "version": "2.5.5",
   "description": "基于蓝鲸 Magicbox 和 Vue 的前端组件库",
   "main": "dist/bk-magic-vue.min.js",
   "files": [


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- bugfix: 修复 tooltip 弹层中无法滚动的问题 && bump to 2.5.5