### PR TITLE
feat: 修复 json5 引发的 CVE-2022-46175

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,9 @@
     "spark-md5": "^3.0.2",
     "tinycolor2": "^1.4.1"
   },
+  "overrides": {
+    "json5": "^2.2.3"
+  },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- feat: 修复 json5 引发的 CVE-2022-46175