### PR TITLE
feat(tag-input): 支持单选聚焦时保持已选标签展示

### DIFF
--- a/bkui-vue2-helper/attributes.json
+++ b/bkui-vue2-helper/attributes.json
@@ -1139,6 +1139,7 @@
   "bk-tag-input/clearable": { "description": "是否允许清空", "default": "true" },
   "bk-tag-input/allow-create": { "description": "是否允许自定义标签输入", "default": "false" },
   "bk-tag-input/max-data": { "description": "是否限制可选个数，-1为不限制", "default": "-1" },
+  "bk-tag-input/keep-selected-tag-on-focus": { "description": "单选时，聚焦后是否保持已选标签展示", "default": "false" },
   "bk-tag-input/use-group": { "description": "是否显示分组", "default": "false" },
   "bk-tag-input/max-result": { "description": "下拉列表搜索结果显示个数，默认为 10", "default": "10" },
   "bk-tag-input/content-width": { "description": "自定义设置下拉弹框的宽度，单选会撑满因此失效", "default": "190" },

--- a/bkui-vue2-helper/tags.json
+++ b/bkui-vue2-helper/tags.json
@@ -741,6 +741,7 @@
       "clearable",
       "allow-create",
       "max-data",
+      "keep-selected-tag-on-focus",
       "use-group",
       "max-result",
       "content-width",

--- a/example/components/tag-input/readme.md
+++ b/example/components/tag-input/readme.md
@@ -1406,6 +1406,7 @@
 | clearable | 是否允许清空 | Boolean | —— | true |
 | allow-create | 是否允许自定义标签输入 | Boolean | —— | false |
 | max-data | 是否限制可选个数，-1为不限制 | Number | —— | -1 |
+| keep-selected-tag-on-focus | 单选时，聚焦后是否保持已选标签展示 | Boolean | —— | false |
 | use-group | 是否显示分组 | Boolean | —— | false |
 | max-result | 下拉列表搜索结果显示个数，默认为 10 | Number | —— | 10 |
 | content-width | 自定义设置下拉弹框的宽度，单选会撑满因此失效 | Number | —— | 190 |

--- a/src/components/tag-input/tag-input.vue
+++ b/src/components/tag-input/tag-input.vue
@@ -169,6 +169,10 @@ export default {
       type: Number,
       default: -1
     },
+    keepSelectedTagOnFocus: {
+      type: Boolean,
+      default: false
+    },
     maxResult: {
       type: Number,
       default: 10
@@ -697,7 +701,10 @@ export default {
       this.$emit('inputchange', value)
       // 在下一次DOM更新后执行回调函数, 以进行动态List的支持
       this.$nextTick(() => {
-        if (this.maxData === -1 || this.maxData > this.tagList.length) {
+        if (this.maxData === -1
+          || this.maxData > this.tagList.length
+          || (this.isSingleSelect && this.keepSelectedTagOnFocus)
+        ) {
           const charLen = this.getCharLength(value)
 
           this.cacheVal = value
@@ -1119,11 +1126,15 @@ export default {
 
         if (this.isSingleSelect) {
           const [oldVal] = this.tagListCache
-          // 如果是单选，且input不为空，即保留了上次的结果则恢复
-          if (inputValue && inputValue === oldVal && this.localTagListCache.length) {
-            this.addTag(this.localTagListCache[0], 'select')
-          } else {
-            this.handlerChange('remove')
+          if (this.tagListCache.length) {
+            // 如果是单选，且input不为空，即保留了上次的结果则恢复
+            if (inputValue && inputValue === oldVal && this.localTagListCache.length) {
+              this.addTag(this.localTagListCache[0], 'select')
+            } else {
+              this.handlerChange('remove')
+            }
+            this.tagListCache = []
+            this.localTagListCache = []
           }
         } else if (this.allowAutoMatch && inputValue) {
           // 如果匹配，则自动选则
@@ -1155,7 +1166,7 @@ export default {
       clearTimeout(this.timer)
 
       // 如果是单选，在获取焦点时自动定位为当前值
-      if (this.isSingleSelect && this.tagList.length) {
+      if (this.isSingleSelect && this.tagList.length && !this.keepSelectedTagOnFocus) {
         this.tagListCache = [...this.tagList]
         this.localTagListCache = [...this.localTagList]
 

--- a/test/tag-input.focus.spec.js
+++ b/test/tag-input.focus.spec.js
@@ -6,7 +6,7 @@ const vm = require('vm')
 function loadTagInputComponent () {
   const filePath = path.resolve(__dirname, '../src/components/tag-input/tag-input.vue')
   const content = fs.readFileSync(filePath, 'utf8')
-  const scriptMatch = content.match(/<script>([\s\S]*?)<\/script>/)
+  const scriptMatch = content.match(/<script>([\s\S]*?)<\/script>/i)
 
   if (!scriptMatch) {
     throw new Error('Cannot find tag-input script block')

--- a/test/tag-input.focus.spec.js
+++ b/test/tag-input.focus.spec.js
@@ -1,0 +1,225 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const vm = require('vm')
+
+function loadTagInputComponent () {
+  const filePath = path.resolve(__dirname, '../src/components/tag-input/tag-input.vue')
+  const content = fs.readFileSync(filePath, 'utf8')
+  const scriptMatch = content.match(/<script>([\s\S]*?)<\/script>/)
+
+  if (!scriptMatch) {
+    throw new Error('Cannot find tag-input script block')
+  }
+
+  const stubs = `
+    const listRender = {}
+    const tagRender = {}
+    const bkPopover = {}
+    const bkLoading = {}
+    const bkTooltips = {}
+    const bkOverflowTips = {}
+    const locale = { mixin: {} }
+    const emitter = {}
+  `
+
+  const script = scriptMatch[1]
+    .split('\n')
+    .filter(line => !line.trim().startsWith('import '))
+    .join('\n')
+    .replace('export default', 'module.exports =')
+
+  const targetModule = { exports: {} }
+  vm.runInNewContext(`${stubs}\n${script}`, {
+    module: targetModule,
+    exports: targetModule.exports,
+    setTimeout,
+    clearTimeout
+  }, {
+    filename: filePath
+  })
+
+  return targetModule.exports
+}
+
+function getDefaultPropValue (config) {
+  if (!Object.prototype.hasOwnProperty.call(config, 'default')) {
+    return undefined
+  }
+
+  if (typeof config.default === 'function' && config.type !== Function) {
+    return config.default()
+  }
+
+  return config.default
+}
+
+function createRefs () {
+  const tagList = {
+    childNodes: [],
+    appendChild (node) {
+      this.childNodes = this.childNodes.filter(item => item !== node)
+      this.childNodes.push(node)
+      node.parentNode = this
+    },
+    insertBefore (newElement, targetElement) {
+      this.childNodes = this.childNodes.filter(item => item !== newElement)
+      const targetIndex = this.childNodes.indexOf(targetElement)
+      const insertIndex = targetIndex === -1 ? this.childNodes.length : targetIndex
+      this.childNodes.splice(insertIndex, 0, newElement)
+      newElement.parentNode = this
+    },
+    querySelectorAll () {
+      return []
+    }
+  }
+  const staffInput = {
+    id: 'staffInput',
+    offsetLeft: 0,
+    offsetTop: 0,
+    getAttribute (name) {
+      return name === 'role' ? 'input' : null
+    },
+    nextSibling: null,
+    parentNode: tagList
+  }
+
+  tagList.childNodes.push(staffInput)
+
+  return {
+    bkTagSelector: {
+      clientWidth: 300
+    },
+    tagInputDropdown: {
+      instance: {
+        state: {
+          isShown: false
+        },
+        set () {},
+        show () {
+          this.state.isShown = true
+        },
+        popperInstance: {
+          update () {}
+        }
+      }
+    },
+    selectorList: {
+      scrollTop: 0,
+      removeEventListener () {},
+      addEventListener () {}
+    },
+    tagList,
+    staffInput,
+    input: {
+      style: {},
+      focus () {}
+    }
+  }
+}
+
+function createTagInputInstance (propOverrides) {
+  const component = loadTagInputComponent()
+  const props = Object.keys(component.props).reduce((result, key) => {
+    result[key] = getDefaultPropValue(component.props[key])
+    return result
+  }, {})
+
+  const emitted = []
+  const vm = {
+    ...props,
+    ...propOverrides,
+    emitted,
+    $refs: createRefs(),
+    $emit (...args) {
+      emitted.push(args)
+    },
+    dispatch () {},
+    t (key) {
+      return key
+    },
+    $nextTick (callback) {
+      if (typeof callback === 'function') {
+        callback()
+      }
+      return Promise.resolve()
+    }
+  }
+
+  Object.assign(vm, component.data.call(vm))
+  Object.keys(component.methods).forEach(methodName => {
+    vm[methodName] = component.methods[methodName].bind(vm)
+  })
+  component.created.call(vm)
+  vm.bkTagSelector = vm.$refs.bkTagSelector
+  vm.popoverInstance = vm.$refs.tagInputDropdown
+
+  return vm
+}
+
+function createSelectedSingleTagInput (propOverrides = {}) {
+  return createTagInputInstance({
+    value: ['apple'],
+    list: [
+      { id: 'apple', name: 'Apple' },
+      { id: 'banana', name: 'Banana' }
+    ],
+    maxData: 1,
+    allowCreate: true,
+    trigger: 'focus',
+    ...propOverrides
+  })
+}
+
+function focusInput (vm) {
+  vm.focusInputer({
+    target: {
+      className: 'bk-tag-input'
+    }
+  })
+}
+
+function testSingleSelectKeepsEditModeByDefault () {
+  const vm = createSelectedSingleTagInput()
+
+  focusInput(vm)
+
+  assert.deepStrictEqual(Array.from(vm.tagList), [])
+  assert.strictEqual(vm.localTagList.length, 0)
+  assert.strictEqual(vm.curInputValue, 'apple')
+  assert.deepStrictEqual(Array.from(vm.renderList).map(item => item.id), ['apple', 'banana'])
+}
+
+function testSingleSelectCanKeepSelectedTagOnFocus () {
+  const vm = createSelectedSingleTagInput({
+    keepSelectedTagOnFocus: true
+  })
+
+  assert.deepStrictEqual(Array.from(vm.tagList), ['apple'])
+  assert.strictEqual(vm.localTagList[0].name, 'Apple')
+
+  focusInput(vm)
+
+  assert.deepStrictEqual(Array.from(vm.tagList), ['apple'])
+  assert.strictEqual(vm.localTagList.length, 1)
+  assert.strictEqual(vm.localTagList[0].name, 'Apple')
+  assert.strictEqual(vm.curInputValue, '')
+
+  vm.curInputValue = 'ba'
+  vm.handleInput({
+    target: {
+      value: 'ba'
+    }
+  })
+
+  assert.deepStrictEqual(Array.from(vm.tagList), ['apple'])
+  assert.deepStrictEqual(Array.from(vm.renderList).map(item => item.id), ['banana'])
+  assert.strictEqual(vm.emitted.some(([eventName]) => eventName === 'remove'), false)
+}
+
+function run () {
+  testSingleSelectKeepsEditModeByDefault()
+  testSingleSelectCanKeepSelectedTagOnFocus()
+}
+
+run()


### PR DESCRIPTION
## 变更点

- 为 `bk-tag-input` 新增 `keep-selected-tag-on-focus` 配置，用于控制单选聚焦时是否保持已选标签展示。
- 默认保留 `max-data=1` 时原有的编辑/搜索替换交互，避免影响已有业务。
- 开启配置后，单选聚焦时继续展示已选 tag，同时仍支持输入关键字筛选并替换选项。
- 补充默认行为和新配置行为的回归测试。
- 更新 helper 元数据与 tag-input 属性文档。

## 相关 issue

Refs #681
Refs #682

## 验证

- `node test/tag-input.focus.spec.js`
- `npx eslint src/components/tag-input/tag-input.vue`
- `npx eslint --env node test/tag-input.focus.spec.js`
- `node -e "JSON.parse(require('fs').readFileSync('bkui-vue2-helper/attributes.json','utf8')); JSON.parse(require('fs').readFileSync('bkui-vue2-helper/tags.json','utf8'))"`
- `git diff --check`